### PR TITLE
feat(nextcloud-mcp): deploy nextcloud-mcp-server

### DIFF
--- a/manifests/flux-system/sources.yaml
+++ b/manifests/flux-system/sources.yaml
@@ -202,3 +202,12 @@ metadata:
 spec:
   interval: 24h0m0s
   url: https://pkgs.tailscale.com/helmcharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cbcoutinho
+  namespace: flux-system
+spec:
+  interval: 24h0m0s
+  url: https://cbcoutinho.github.io/helm-charts/

--- a/manifests/nextcloud-mcp/helm.yaml
+++ b/manifests/nextcloud-mcp/helm.yaml
@@ -1,0 +1,56 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nextcloud-mcp
+  namespace: nextcloud-mcp
+spec:
+  interval: 24h
+  chart:
+    spec:
+      chart: nextcloud-mcp-server
+      version: "0.61.0"
+      sourceRef:
+        kind: HelmRepository
+        name: cbcoutinho
+        namespace: flux-system
+      interval: 24h
+  values:
+    nextcloud:
+      host: "https://cloud.seymour.family"
+      mcpServerUrl: "https://cloud-mcp.seymour.family"
+
+    auth:
+      mode: login-flow
+      loginFlow:
+        existingSecret: "nextcloud-mcp-login-flow"
+        tokenEncryptionKeyKey: "token_encryption_key"
+        persistence:
+          enabled: true
+          storageClass: "truenas-iscsi-csi"
+          size: 100Mi
+
+    dataStorage:
+      enabled: true
+      storageClass: "truenas-iscsi-csi"
+      size: 1Gi
+
+    ingress:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-production
+      hosts:
+        - host: cloud-mcp.seymour.family
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: nextcloud-mcp-tls
+          hosts:
+            - cloud-mcp.seymour.family
+
+    serviceMonitor:
+      enabled: true
+
+    dashboards:
+      enabled: true

--- a/manifests/nextcloud-mcp/kustomization.yaml
+++ b/manifests/nextcloud-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm.yaml
+  - sealedsecret.yaml

--- a/manifests/nextcloud-mcp/namespace.yaml
+++ b/manifests/nextcloud-mcp/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextcloud-mcp

--- a/manifests/nextcloud-mcp/sealedsecret.yaml
+++ b/manifests/nextcloud-mcp/sealedsecret.yaml
@@ -1,0 +1,12 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: nextcloud-mcp-login-flow
+  namespace: nextcloud-mcp
+spec:
+  encryptedData:
+    token_encryption_key: AgADzDcr0mAc2CtKbcSXxpMM7Dns8MwS5ufFJMVgbjXxYa4+vpfbVtSYvM351b/6c0EutciwTcTJ8+R1ELdvbZ08WRwmIURjIqkS67aJqlG9Mo5gIOF34uZLYbYdJguJ43r6LoJI3ykxZTO8OKztFUuCZm/XzUuqraQhvl7BNQ8x+semi8z2xTzI7rBJOiAQpXD+MyPuywZyLVb12Om5sm7TkQRIpWpklrkUahEE55zCLPdbcljmfBiM7Zt5dMbOv7uiwg+km9DFQerNJ2tg7azkskgLqBICiAFK9eFsFi+NAUrYZ/4TzOJCmSkuni1puIW3U3cB9GB4c2Q4+BwI1UJ9eKDLl1g207Pwqk/TMBbByahLBsolbcmAi6y+TYdOuMYXVXF6ChGtGQ2bM7SUFY1nyUkgWGzoAeyMYB26BkADQIyoMafBn3mJObbsh+ZpuNhRlpEITBv8AeTIp4P/ZpgR/8eaoEsBU4RYLbLfkz6mfKwQEl0kD6U2uogJhZ6jTg04B2jljAFwPmXGEMrBoNPV9ARHZam2zaCOFDKifY+FS2m3M5SYXw5mCW7ZkDc0FMdTcGMQv9W7kGAiouDVnQLUWQXwWwJhNyY/8S22l6iF2MkQ4wxXOhgjs6eT3tqpYTz9Rcz4F5fT3xrQqZwcO44qka37npcWGK0xcmK3N0TdRLSKyPHdJMzkr5EZInARu7E04ps9lgJSfYxSb7nvk2YKoz4TiRYZ4iLOF0TFB/zxC86SbDMPIJomTVAETg==
+  template:
+    metadata:
+      name: nextcloud-mcp-login-flow
+      namespace: nextcloud-mcp


### PR DESCRIPTION
## Summary

- Adds `cbcoutinho` HelmRepository source pointing to `https://cbcoutinho.github.io/helm-charts/`
- Deploys `nextcloud-mcp-server` v0.61.0 in the `nextcloud-mcp` namespace
- Configures Login Flow v2 auth (multi-user, no Nextcloud patches required) with a sealed token encryption key
- Ingress at `cloud-mcp.seymour.family` via Traefik with Let's Encrypt TLS
- Persistent storage on `truenas-iscsi-csi` for token DB and login-flow OAuth data
- ServiceMonitor and Grafana dashboard provisioning enabled

## Test plan

- [ ] Flux reconciles `cbcoutinho` HelmRepository successfully
- [ ] `nextcloud-mcp` namespace and HelmRelease are created
- [ ] Pod comes up healthy (liveness/readiness probes pass)
- [ ] `https://cloud-mcp.seymour.family` is reachable and TLS cert issues
- [ ] Login Flow redirects to `https://cloud.seymour.family` for user auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)