### PR TITLE
fix(traefik,synapse): prevent control-plane scheduling and fix Matrix…

### DIFF
--- a/manifests/synapse/helm.yaml
+++ b/manifests/synapse/helm.yaml
@@ -18,7 +18,7 @@ spec:
   values:
     wellKnownDelegation:
       baseDomainRedirect:
-        enabled: false
+        enabled: true
     certManager:
       clusterIssuer: letsencrypt-production
     elementAdmin:

--- a/manifests/traefik/helm.yaml
+++ b/manifests/traefik/helm.yaml
@@ -26,6 +26,13 @@ spec:
   values:
     deployment:
       replicas: 2
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: traefik
     ports:
       web:
         http:


### PR DESCRIPTION
… base domain

Add topologySpreadConstraints to Traefik so replicas always spread across different nodes, ensuring at least one pod lands on a MetalLB-eligible worker node. Without this, both pods can schedule onto the Talos control-plane node (excluded from external load balancers), causing MetalLB to drop all traffic to the 192.168.1.90 VIP.

Enable wellKnownDelegation.baseDomainRedirect on the matrix-stack chart so seymour.family redirects to chat.seymour.family instead of returning 404. This makes the base domain behave like a Matrix server to clients and tools that probe it directly rather than following .well-known delegation.