### PR TITLE
fix(tubearchivist): run as root to match image python package layout

### DIFF
--- a/manifests/tubearchivist/deployment.yaml
+++ b/manifests/tubearchivist/deployment.yaml
@@ -16,10 +16,6 @@ spec:
       labels:
         app.kubernetes.io/name: tubearchivist
     spec:
-      securityContext:
-        runAsUser: 568
-        runAsGroup: 568
-        fsGroup: 568
       containers:
         - name: tubearchivist
           image: bbilly1/tubearchivist


### PR DESCRIPTION
## Summary

- Removes pod-level `securityContext` (`runAsUser: 568`, `runAsGroup: 568`, `fsGroup: 568`)
- TubeArchivist installs all Python packages into `/root/.local/lib/python3.13/site-packages/` — running as UID 568 hides them from `sys.path`, causing the `ModuleNotFoundError: No module named 'django'` crash loop
- File ownership for NFS mounts is handled internally by the app via `HOST_UID`/`HOST_GID` env vars

## Root cause

Found by exec-ing into the image with `sleep 3600` and inspecting the Python path. System site-packages only contains `pip`; all app dependencies live in `/root/.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF