### PR TITLE
fix(tubearchivist): add startupProbe to handle slow ES-dependent startup

### DIFF
--- a/manifests/tubearchivist/deployment.yaml
+++ b/manifests/tubearchivist/deployment.yaml
@@ -52,19 +52,23 @@ spec:
             limits:
               cpu: "1"
               memory: 1Gi
+          startupProbe:
+            httpGet:
+              path: /api/health/
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /api/health/
               port: http
-            initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 10
-            failureThreshold: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /api/health/
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
       volumes:


### PR DESCRIPTION
## Summary

- Adds a `startupProbe` that gives the app up to 300s (30 × 10s) to become healthy before liveness kicks in
- Removes `initialDelaySeconds` from liveness/readiness (startupProbe replaces that role)
- Tightens liveness `failureThreshold` to 3 once the app is running

## Why

TubeArchivist's `run.sh` runs Django migrations, validates Elasticsearch indices, and waits for ES connectivity before starting nginx. This setup phase takes 60-120s. The previous `initialDelaySeconds: 60` + `failureThreshold: 5` window (210s total) was too narrow — the liveness probe was killing the container during startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF