### PR TITLE
fix(tubearchivist): set Host header on probes for Django ALLOWED_HOSTS

### DIFF
--- a/manifests/tubearchivist/deployment.yaml
+++ b/manifests/tubearchivist/deployment.yaml
@@ -56,12 +56,18 @@ spec:
             httpGet:
               path: /api/health/
               port: http
+              httpHeaders:
+                - name: Host
+                  value: jellytube.seymour.family
             periodSeconds: 10
             failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /api/health/
               port: http
+              httpHeaders:
+                - name: Host
+                  value: jellytube.seymour.family
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
@@ -69,6 +75,9 @@ spec:
             httpGet:
               path: /api/health/
               port: http
+              httpHeaders:
+                - name: Host
+                  value: jellytube.seymour.family
             periodSeconds: 10
             timeoutSeconds: 5
       volumes:


### PR DESCRIPTION
## Summary

- Adds `Host: jellytube.seymour.family` header to all three probes (startup, liveness, readiness)

## Root cause

Django's `ALLOWED_HOSTS` is derived from `TA_HOST=https://jellytube.seymour.family`. The kubelet sends probe requests with the pod IP as the `Host` header (e.g. `10.244.0.227:8000`), which Django rejects with HTTP 400. Requests from `localhost` pass because Django always allows it, so manual in-pod checks returned 200 while the kubelet probes returned 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF