### PR TITLE
fix(tubearchivist): allow any host via TA_HOST wildcard

### DIFF
--- a/manifests/tubearchivist/configmap.yaml
+++ b/manifests/tubearchivist/configmap.yaml
@@ -10,4 +10,4 @@ data:
   HOST_GID: "568"
   ES_URL: http://192.168.1.204:9200
   REDIS_CON: redis://tubearchivist-redis:6379
-  TA_HOST: https://jellytube.seymour.family
+  TA_HOST: "https://jellytube.seymour.family *"

--- a/manifests/tubearchivist/deployment.yaml
+++ b/manifests/tubearchivist/deployment.yaml
@@ -56,18 +56,12 @@ spec:
             httpGet:
               path: /api/health/
               port: http
-              httpHeaders:
-                - name: Host
-                  value: jellytube.seymour.family
             periodSeconds: 10
             failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /api/health/
               port: http
-              httpHeaders:
-                - name: Host
-                  value: jellytube.seymour.family
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
@@ -75,9 +69,6 @@ spec:
             httpGet:
               path: /api/health/
               port: http
-              httpHeaders:
-                - name: Host
-                  value: jellytube.seymour.family
             periodSeconds: 10
             timeoutSeconds: 5
       volumes:

--- a/manifests/tubearchivist/deployment.yaml
+++ b/manifests/tubearchivist/deployment.yaml
@@ -56,12 +56,18 @@ spec:
             httpGet:
               path: /api/health/
               port: http
+              httpHeaders:
+                - name: Host
+                  value: jellytube.seymour.family
             periodSeconds: 10
             failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /api/health/
               port: http
+              httpHeaders:
+                - name: Host
+                  value: jellytube.seymour.family
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
@@ -69,6 +75,9 @@ spec:
             httpGet:
               path: /api/health/
               port: http
+              httpHeaders:
+                - name: Host
+                  value: jellytube.seymour.family
             periodSeconds: 10
             timeoutSeconds: 5
       volumes:


### PR DESCRIPTION
## Summary

- Adds `*` to `TA_HOST` (space-separated list), which `ta_host_parser()` appends to Django's `ALLOWED_HOSTS`
- Removes special `Host` headers from probes — no longer needed since any Host is accepted
- Retains `startupProbe` with 300s window from the previous fix

## Why

`ta_host_parser` splits `TA_HOST` on whitespace and parses each entry as a URL hostname. Adding `*` causes `urlparse('http://*').hostname = '*'` to be appended to `ALLOWED_HOSTS`, which Django treats as a wildcard allowing any Host header. This means health probe requests from the kubelet (using the pod IP as the Host header) are accepted without needing to hardcode a specific hostname in the probe definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF