### PR TITLE
feat(tubearchivist): enable automatic yt-dlp release updates

### DIFF
--- a/manifests/tubearchivist/configmap.yaml
+++ b/manifests/tubearchivist/configmap.yaml
@@ -11,3 +11,4 @@ data:
   ES_URL: http://192.168.1.204:9200
   REDIS_CON: redis://tubearchivist-redis:6379
   TA_HOST: "https://jellytube.seymour.family *"
+  TA_AUTO_UPDATE_YTDLP: release


### PR DESCRIPTION
## Summary

- Sets `TA_AUTO_UPDATE_YTDLP=release` in the ConfigMap so yt-dlp is updated to the latest stable release on each container start

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF