### PR TITLE
feat(tubearchivist): mount youtube subdirectory of media PVC

### DIFF
--- a/manifests/tubearchivist/deployment.yaml
+++ b/manifests/tubearchivist/deployment.yaml
@@ -43,6 +43,7 @@ spec:
           volumeMounts:
             - name: media
               mountPath: /youtube
+              subPath: youtube
             - name: cache
               mountPath: /cache
           resources:


### PR DESCRIPTION
## Summary

- Adds `subPath: youtube` to the media volumeMount so TubeArchivist writes to `/mnt/media/data/media/youtube` on TrueNAS rather than the root of the media share

## Note

The `youtube` subdirectory must exist on the NFS share before the pod restarts, otherwise the mount will fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF