### PR TITLE
fix(tubearchivist): set HOST_UID to 1000, HOST_GID to 568

### DIFF
--- a/manifests/tubearchivist/configmap.yaml
+++ b/manifests/tubearchivist/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: tubearchivist
 data:
   TZ: America/Los_Angeles
-  HOST_UID: "568"
+  HOST_UID: "1000"
   HOST_GID: "568"
   ES_URL: http://192.168.1.204:9200
   REDIS_CON: redis://tubearchivist-redis:6379


### PR DESCRIPTION
## Summary

- Sets `HOST_UID=1000` and `HOST_GID=568` so TubeArchivist chowns downloaded files to the correct ownership on the NFS share

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF