### PR TITLE
fix(tubearchivist): increase memory limit to 2Gi to prevent OOMKill

### DIFF
--- a/manifests/tubearchivist/deployment.yaml
+++ b/manifests/tubearchivist/deployment.yaml
@@ -49,10 +49,10 @@ spec:
           resources:
             requests:
               cpu: 250m
-              memory: 256Mi
+              memory: 512Mi
             limits:
-              cpu: "1"
-              memory: 1Gi
+              cpu: "2"
+              memory: 2Gi
           startupProbe:
             httpGet:
               path: /api/health/


### PR DESCRIPTION
## Summary

- Raises memory limit from 1Gi → 2Gi and request from 256Mi → 512Mi
- Raises CPU limit from 1 → 2 to give headroom during yt-dlp updates and indexing

## Why

The container runs nginx + 4 uvicorn workers + 4 Celery workers + beat scheduler in a single pod. 1Gi was insufficient and the pod was being OOMKilled repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF