### PR TITLE
fix(tubearchivist): increase cache PVC from 10Gi to 20Gi

### DIFF
--- a/manifests/tubearchivist/storage.yaml
+++ b/manifests/tubearchivist/storage.yaml
@@ -38,5 +38,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi
   storageClassName: truenas-nfs-csi


### PR DESCRIPTION
## Summary

- Increases the `cache` PVC request from 10Gi to 20Gi after disk quota exceeded error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdhhsTgD8SuaUqKhw3T6KF