### PR TITLE
feat(audiobookshelf): deploy Audiobookshelf

### DIFF
--- a/manifests/audiobookshelf/configmap.yaml
+++ b/manifests/audiobookshelf/configmap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audiobookshelf
+  namespace: audiobookshelf
+data:
+  TZ: America/Los_Angeles
+  AUDIOBOOKSHELF_UID: "1000"
+  AUDIOBOOKSHELF_GID: "568"

--- a/manifests/audiobookshelf/deployment.yaml
+++ b/manifests/audiobookshelf/deployment.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audiobookshelf
+  namespace: audiobookshelf
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: audiobookshelf
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: audiobookshelf
+    spec:
+      containers:
+        - name: audiobookshelf
+          image: ghcr.io/advplyr/audiobookshelf
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: audiobookshelf
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: media
+              mountPath: /audiobooks
+              subPath: audiobooks
+            - name: media
+              mountPath: /podcasts
+              subPath: podcasts
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: config
+        - name: media
+          persistentVolumeClaim:
+            claimName: media

--- a/manifests/audiobookshelf/deployment.yaml
+++ b/manifests/audiobookshelf/deployment.yaml
@@ -36,6 +36,8 @@ spec:
             - name: media
               mountPath: /podcasts
               subPath: podcasts
+            - name: metadata
+              mountPath: /metadata
           resources:
             requests:
               cpu: 500m
@@ -62,6 +64,11 @@ spec:
               port: http
             periodSeconds: 10
             timeoutSeconds: 5
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
         - name: config
           persistentVolumeClaim:
@@ -69,3 +76,6 @@ spec:
         - name: media
           persistentVolumeClaim:
             claimName: media
+        - name: metadata
+          persistentVolumeClaim:
+            claimName: metadata

--- a/manifests/audiobookshelf/ingress.yaml
+++ b/manifests/audiobookshelf/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: audiobookshelf
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: books.seymour.family
+      http:
+        paths:
+          - backend:
+              service:
+                name: audiobookshelf
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - books.seymour.family
+      secretName: audiobookshelf-tls

--- a/manifests/audiobookshelf/kustomization.yaml
+++ b/manifests/audiobookshelf/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: audiobookshelf
+resources:
+  - namespace.yaml
+  - storage.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: audiobookshelf
+images:
+  - name: ghcr.io/advplyr/audiobookshelf
+    newTag: "2.35.1"

--- a/manifests/audiobookshelf/namespace.yaml
+++ b/manifests/audiobookshelf/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: audiobookshelf
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: privileged

--- a/manifests/audiobookshelf/service.yaml
+++ b/manifests/audiobookshelf/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: audiobookshelf
+  namespace: audiobookshelf
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: audiobookshelf
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/manifests/audiobookshelf/storage.yaml
+++ b/manifests/audiobookshelf/storage.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: audiobookshelf-media
+  namespace: audiobookshelf
+spec:
+  capacity:
+    storage: 4Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  nfs:
+    path: /mnt/media/data/media
+    server: 192.168.1.100
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media
+  namespace: audiobookshelf
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 4Ti
+  storageClassName: nfs
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: config
+  namespace: audiobookshelf
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: truenas-iscsi-csi

--- a/manifests/audiobookshelf/storage.yaml
+++ b/manifests/audiobookshelf/storage.yaml
@@ -11,6 +11,9 @@ spec:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: nfs
+  claimRef:
+    name: media
+    namespace: audiobookshelf
   nfs:
     path: /mnt/media/data/media
     server: 192.168.1.100
@@ -39,4 +42,17 @@ spec:
   resources:
     requests:
       storage: 10Gi
+  storageClassName: truenas-iscsi-csi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: metadata
+  namespace: audiobookshelf
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
   storageClassName: truenas-iscsi-csi


### PR DESCRIPTION
## Summary
- Deploy Audiobookshelf (self-hosted audiobook/podcast server) as a new raw-manifest app,
  following the same no-Helm-chart pattern already used for tubearchivist.
- Storage split: `truenas-iscsi-csi` block volumes for `/config` (SQLite) and `/metadata`
  (covers/scan cache/backups — must not sit on NFS), plus the existing shared NFS media export
  reused via `subPath` for `/audiobooks` and `/podcasts`.
- Exposed via Traefik Ingress + cert-manager at `books.seymour.family` (ClusterIP Service,
  unlike tubearchivist's Tailscale LoadBalancer).
- Pod runs as non-root (`runAsUser: 1000`, `runAsGroup: 568`, `fsGroup: 568`), matching the
  ownership already set on the shared media directories.

## Test plan
- [x] `kustomize build manifests/audiobookshelf` renders all 8 resources cleanly with correct
      namespace/labels/image tag
- [x] Server-side `kubectl apply --dry-run=server` against the live cluster passes for every
      resource
- [x] Confirmed `truenas-iscsi-csi`/`truenas-nfs-csi` storage classes, `letsencrypt-production`
      ClusterIssuer, and `traefik` IngressClass all exist on-cluster
- [x] Created and verified ownership (`1000:568`) of the `audiobooks`/`podcasts` subdirectories
      on the shared NFS export, required for the Deployment's subPath mounts to succeed
- [x] Reviewed for correctness/security/convention/runtime-risk; addressed missing `/metadata`
      mount, PV `claimRef` pinning, and pod `securityContext`
- [ ] Confirm pod starts cleanly and completes first library scan once Flux reconciles this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)